### PR TITLE
Dynamic LTI provider based on req

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -10,9 +10,15 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'lti';
   this._passReqToCallback = options.passReqToCallback;
-  this._provider = new lti.Provider(options.consumerKey,
-                                    options.consumerSecret,
-                                    options.nonceStore);
+  if (options.createProvider) {
+    this._createProvider = options.createProvider;
+  } else {
+    var provider = new lti.Provider(options.consumerKey,
+                                      options.consumerSecret,
+                                      options.nonceStore);
+
+    this._createProvider = function(req, cb) { cb(null, provider) }
+  }
   this._verify = verify;
 }
 
@@ -31,19 +37,23 @@ Strategy.prototype.authenticate = function(req, options) {
     return self.success(user, info);
   }
 
-  self._provider.valid_request(req, function(err, valid) {
+  self._createProvider(req, function(err, provider) {
     if (err) return self.error(err);
-    if (!valid) return self.fail();
 
-    try {
-      if (self._passReqToCallback) {
-        return self._verify(req, self._provider.body, verified);
-      } else {
-        return self._verify(self._provider.body, verified);
+    provider.valid_request(req, function(err, valid) {
+      if (err) return self.error(err);
+      if (!valid) return self.fail();
+
+      try {
+        if (self._passReqToCallback) {
+          return self._verify(req, provider.body, verified);
+        } else {
+          return self._verify(provider.body, verified);
+        }
+      } catch (ex) {
+        return self.error(ex);
       }
-    } catch (ex) {
-      return self.error(ex);
-    }
+    });
   });
 };
 

--- a/test/strategy.normal.test.js
+++ b/test/strategy.normal.test.js
@@ -46,4 +46,53 @@ describe('Strategy', function() {
       });
     });
   });
+  describe('handle dynamic oauth secrets', function() {
+    // example createProvider, you might end up looking instituion, etc to find the shared secrets
+    function createProvider(req, cb) {
+      cb(null, new lti.Provider(req.body.consumerKey, req.body.consumerSecret));
+    }
+
+
+    var strategy = new Strategy({createProvider: createProvider}, function(lti, done) {
+      return done(null, {
+        id: lti.user_id
+      }, {
+        scope: 'read'
+      });
+    });
+
+    var user;
+    var info;
+    before(function(done) {
+      chai.passport.use(strategy)
+      .success(function(u, i) {
+        user = u;
+        info = i;
+        done();
+      })
+      .req(function(req) {
+        req.body = CONFIG.body();
+        req.body.consumerSecret = CONFIG.lti.consumerSecret;
+        req.body.consumerKey = CONFIG.lti.consumerKey;
+        req.get = function() {
+          return 'test-get';
+        };
+        var provider = new lti.Provider(req.body.consumerKey, req.body.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+      })
+      .authenticate();
+    });
+
+    it('should supply user', function() {
+      expect(user).to.be.an.object;
+      expect(user.id).to.equal('1234');
+    });
+
+    it('should supply info', function() {
+      expect(info).to.be.an.object;
+      expect(info).to.deep.equal({
+        scope: 'read'
+      });
+    });
+  });
 });


### PR DESCRIPTION
In some LTI tools, it may be possible to have multiple consumers of the tool and the ability to have per consumer oauth tokens allows for a more robust security model. Specifically, in hosted canvas, LTI tools are passed `tool_consumer_instance_guid` which can be used to look up consumer specific oauth secrests.

This adds the ability to provide a `createProvider` function as an option to the LTI Strategy which can dynamically inject a new lti provider per request. 

