### PR TITLE
Upgrade to ims-lto 2.x and update test API

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -10,9 +10,15 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'lti';
   this._passReqToCallback = options.passReqToCallback;
-  this._provider = new lti.Provider(options.consumerKey,
-                                    options.consumerSecret,
-                                    options.nonceStore);
+  if (options.createProvider) {
+    this._createProvider = options.createProvider;
+  } else {
+    var provider = new lti.Provider(options.consumerKey,
+                                      options.consumerSecret,
+                                      options.nonceStore);
+
+    this._createProvider = function(req, cb) { cb(null, provider) }
+  }
   this._verify = verify;
 }
 
@@ -31,19 +37,23 @@ Strategy.prototype.authenticate = function(req, options) {
     return self.success(user, info);
   }
 
-  self._provider.valid_request(req, function(err, valid) {
+  self._createProvider(req, function(err, provider) {
     if (err) return self.error(err);
-    if (!valid) return self.fail();
 
-    try {
-      if (self._passReqToCallback) {
-        return self._verify(req, self._provider.body, verified);
-      } else {
-        return self._verify(self._provider.body, verified);
+    provider.valid_request(req, function(err, valid) {
+      if (err) return self.error(err);
+      if (!valid) return self.fail();
+
+      try {
+        if (self._passReqToCallback) {
+          return self._verify(req, provider.body, verified);
+        } else {
+          return self._verify(provider.body, verified);
+        }
+      } catch (ex) {
+        return self.error(ex);
       }
-    } catch (ex) {
-      return self.error(ex);
-    }
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "passport-strategy": "1.0.x"
   },
   "peerDependencies": {
-    "ims-lti": "1.0.x"
+    "ims-lti": "2.1.x"
   },
   "main": "./lib",
   "devDependencies": {
-    "ims-lti": "1.0.x",
+    "ims-lti": "2.1.x",
     "chai": "^1.9.1",
     "chai-passport-strategy": "^0.2.0",
     "mocha": "^2.0.0"

--- a/test/strategy.error.test.js
+++ b/test/strategy.error.test.js
@@ -21,10 +21,11 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.get = function() {
           return 'test-get';
         };
-        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, req.body, CONFIG.lti.consumerSecret);
       })
       .authenticate();
     });
@@ -51,10 +52,11 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.get = function() {
           return 'test-get';
         };
-        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, req.body, CONFIG.lti.consumerSecret);
       })
       .authenticate();
     });
@@ -81,6 +83,7 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.get = function() {
           return 'test-get';
         };

--- a/test/strategy.fail.test.js
+++ b/test/strategy.fail.test.js
@@ -21,10 +21,11 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.get = function() {
           return 'test-get';
         };
-        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, req.body, CONFIG.lti.consumerSecret);
       })
       .authenticate();
     });
@@ -52,10 +53,11 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.get = function() {
           return 'test-get';
         };
-        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, req.body, CONFIG.lti.consumerSecret);
       })
       .authenticate();
     });
@@ -82,6 +84,7 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.body.lti_message_type = 'not-lti-launch-request';
         req.get = function() {
           return 'test-get';

--- a/test/strategy.normal.test.js
+++ b/test/strategy.normal.test.js
@@ -46,4 +46,53 @@ describe('Strategy', function() {
       });
     });
   });
+  describe('handle dynamic oauth secrets', function() {
+    // example createProvider, you might end up looking instituion, etc to find the shared secrets
+    function createProvider(req, cb) {
+      cb(null, new lti.Provider(req.body.consumerKey, req.body.consumerSecret));
+    }
+
+
+    var strategy = new Strategy({createProvider: createProvider}, function(lti, done) {
+      return done(null, {
+        id: lti.user_id
+      }, {
+        scope: 'read'
+      });
+    });
+
+    var user;
+    var info;
+    before(function(done) {
+      chai.passport.use(strategy)
+      .success(function(u, i) {
+        user = u;
+        info = i;
+        done();
+      })
+      .req(function(req) {
+        req.body = CONFIG.body();
+        req.body.consumerSecret = CONFIG.lti.consumerSecret;
+        req.body.consumerKey = CONFIG.lti.consumerKey;
+        req.get = function() {
+          return 'test-get';
+        };
+        var provider = new lti.Provider(req.body.consumerKey, req.body.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+      })
+      .authenticate();
+    });
+
+    it('should supply user', function() {
+      expect(user).to.be.an.object;
+      expect(user.id).to.equal('1234');
+    });
+
+    it('should supply info', function() {
+      expect(info).to.be.an.object;
+      expect(info).to.deep.equal({
+        scope: 'read'
+      });
+    });
+  });
 });

--- a/test/strategy.normal.test.js
+++ b/test/strategy.normal.test.js
@@ -26,10 +26,11 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http';
         req.get = function() {
           return 'test-get';
         };
-        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, req.body, CONFIG.lti.consumerSecret);
       })
       .authenticate();
     });
@@ -72,13 +73,14 @@ describe('Strategy', function() {
       })
       .req(function(req) {
         req.body = CONFIG.body();
+        req.protocol = 'http'
         req.body.consumerSecret = CONFIG.lti.consumerSecret;
         req.body.consumerKey = CONFIG.lti.consumerKey;
         req.get = function() {
           return 'test-get';
         };
         var provider = new lti.Provider(req.body.consumerKey, req.body.consumerSecret);
-        req.body.oauth_signature = provider.signer.build_signature(req, CONFIG.lti.consumerSecret);
+        req.body.oauth_signature = provider.signer.build_signature(req, req.body, CONFIG.lti.consumerSecret);
       })
       .authenticate();
     });


### PR DESCRIPTION
This depends on #6 

ims-lti 2.x changes the API of `signer.build_signature` and also now validates the http url, which requires setting the protocol on the request.

This implements those changes required to move to 2.x

This also fixes #2 